### PR TITLE
feat: protect students routes with auth guard and returnUrl (#3)

### DIFF
--- a/client/src/app/core/guards/auth-guard.spec.ts
+++ b/client/src/app/core/guards/auth-guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { authGuard } from './auth-guard';
+
+describe('authGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/client/src/app/core/guards/auth-guard.ts
+++ b/client/src/app/core/guards/auth-guard.ts
@@ -1,0 +1,17 @@
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+import { Auth } from './../../features/auth/services/auth';
+import { Router } from '@angular/router';
+
+export const authGuard: CanActivateFn = (route, state) => {
+  const auth = inject(Auth);
+  const router = inject(Router);
+
+  if (auth.isLoggedIn()) {
+    return true;
+  }
+
+  return router.createUrlTree(['/login'], {
+    queryParams: { returnUrl: state.url },
+  });
+};

--- a/client/src/app/features/auth/pages/login-page/login-page.ts
+++ b/client/src/app/features/auth/pages/login-page/login-page.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
 import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
-import { Router } from '@angular/router';
 import { Auth } from '../../services/auth';
 
 @Component({
@@ -31,7 +31,12 @@ export class LoginPage {
 
   //   my self
 
-  constructor(private authService: Auth, private fb: FormBuilder, private router: Router) {
+  constructor(
+    private authService: Auth,
+    private fb: FormBuilder,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {
     this.form = this.fb.group({
       email: [
         '',
@@ -72,7 +77,15 @@ export class LoginPage {
       return;
     }
 
-    // if succeeded, go to students page
-    this.router.navigateByUrl('/students');
+    const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl');
+    const target = this.isSafeReturnUrl(returnUrl) ? returnUrl! : '/students';
+
+    this.router.navigateByUrl(target);
+  }
+
+  private isSafeReturnUrl(url: string | null): boolean {
+    if (!url) return false;
+    // Check if URL is relative and doesn't contain harmful protocols
+    return url.startsWith('/') && !url.startsWith('//');
   }
 }

--- a/client/src/app/features/students/pages/students-list-page/students-list-page.html
+++ b/client/src/app/features/students/pages/students-list-page/students-list-page.html
@@ -1,5 +1,5 @@
 <div class="rounded-2xl border border-white/15 bg-white/10 backdrop-blur-xl p-6 shadow-lg">
-  <h1 class="text-2xl font-semibold">Students</h1>
+  <h1 class="text-2xl font-semibold">Student list</h1>
   <p class="mt-2 opacity-80">
     Placeholder list page. Later this will show a table, search, filters, etc.
   </p>

--- a/client/src/app/features/students/pages/students-list-page/students-list-page.ts
+++ b/client/src/app/features/students/pages/students-list-page/students-list-page.ts
@@ -1,11 +1,10 @@
 import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-students-list-page',
-  imports: [],
+  imports: [RouterModule],
   templateUrl: './students-list-page.html',
   styleUrl: './students-list-page.scss',
 })
-export class StudentsListPage {
-
-}
+export class StudentsListPage {}

--- a/client/src/app/shared/components/app-shell-layout/app-shell.routes.ts
+++ b/client/src/app/shared/components/app-shell-layout/app-shell.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { authGuard } from '../../../core/guards/auth-guard';
 
 export const appShellRoutes: Routes = [
   // ✅ Redirect only for the empty URL
@@ -15,6 +16,7 @@ export const appShellRoutes: Routes = [
   // /students/:id
   {
     path: 'students/:id',
+    canActivate: [authGuard],
     loadComponent: () =>
       import('../../../features/students/pages/student-details-page/student-details-page').then(
         (m) => m.StudentDetailsPage
@@ -24,6 +26,7 @@ export const appShellRoutes: Routes = [
   // /students
   {
     path: 'students',
+    canActivate: [authGuard],
     loadComponent: () =>
       import('../../../features/students/pages/students-list-page/students-list-page').then(
         (m) => m.StudentsListPage

--- a/client/src/app/shared/components/header/header.html
+++ b/client/src/app/shared/components/header/header.html
@@ -26,14 +26,25 @@
             [routerLink]="item.href"
             routerLinkActive="nav-pill--active"
             [routerLinkActiveOptions]="{ exact: item.exact ?? false }"
-            class="nav-pill rounded-xl border border-transparent px-3 py-2 text-sm text-white/80 hover:text-white/95 hover:bg-white/10 transition no-underline"
+            class="nav-pill text-sm whitespace-nowrap no-underline"
           >
             {{ item.label }}
           </a>
+          } @if (authService.isLoggedIn()) {
+          <button
+            type="button"
+            (click)="onLogout()"
+            class="nav-pill text-sm whitespace-nowrap no-underline"
+          >
+            Logout
+          </button>
           }
 
           <!-- Optional: small “status dot” to feel premium -->
-          <div class="hidden sm:block h-2 w-2 ml-1 rounded-full bg-green-500/80"></div>
+
+          <div
+            class="hidden sm:block ml-2 h-2 w-2 rounded-full bg-green-400/80 ring-2 ring-white/15 shadow-[0_0_10px_rgba(34,197,94,0.35)] shrink-0"
+          ></div>
         </nav>
 
         <!-- Right side actions -->


### PR DESCRIPTION
Closes #3

## What changed
- Added authGuard to protect /students and /students/:id
- Redirects unauthenticated users to /login with returnUrl
- After login, navigates back to returnUrl (fallback /students)

## How to test
- Logout (clear localStorage)
- Visit /students/10554101 -> should redirect to /login?returnUrl=...
- Login -> should return to /students/10554101
